### PR TITLE
Added Swiftify Xcode extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ You can find the related blogpost [here](https://theswiftdev.com/2016/08/17/xcod
 Please submit a pull request to improve this file. Thank you to all contributors; you rock!
 
 ### The list
+* [Swiftify Xcode extension](https://itunes.apple.com/us/app/swiftify-objective-c-to-swift/id1183412116) - allows you to convert Objective-C code to Swift right from Xcode.
 * [EasyCode-Xcode](https://github.com/music4kid/EasyCode-Xcode) - "legal" Xcode Plugin for inserting code in super duper fast lazy way.
 * [CodeGenerator](https://github.com/WANGjieJacques/CodeGenerator/) - Xcode editor extension for swift code generation.
 * [GithubIssuesExtension](https://github.com/ambientlight/GithubIssuesExtension) - Xcode editor extension that adds an ability to post and edit github issues through comment templates


### PR DESCRIPTION
Are you fine with a link to AppStore rather than the source code on GitHub?
We did not think of making the extension open source, but we may consider it if you think that's absolutely needed.