### PR TITLE
nef - Xcode Editor Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Please submit a pull request to improve this file. Thank you to all contributors
 * [Xgist](https://github.com/Bunn/Xgist) - Xcode Source Editor Extension that sends code to GitHub's [Gist](https://gist.github.com)
 * [PlayAlways](https://github.com/insidegui/PlayAlways) - Create Xcode playgrounds from your menu bar.
 * [XShared](https://github.com/Otbivnoe/XShared) - Xcode extension which allows you copying the code with special formatting quotes for social (Slack, Telegram)
+* [nef](https://github.com/bow-swift/nef-plugin) - This Xcode extension enables you to make a code selection and export it to a snippets. __Available on Mac App Store__.
 
 ### For Objective-C
 


### PR DESCRIPTION
## Project URL
https://github.com/bow-swift/nef-plugin

## Description
This project provides an extension for Xcode to integrate some nef features directly in the IDE. Using the core of nef, you can export snippets from your code selection directly in Xcode.

You know all of those code screenshots you see on social networks, or at meetups and conferences? Do you want to share images of your code with your team? This Xcode extension makes it easy to create and share beautiful images of your source code.

## Screenshots
![nef-plugin-action-export](https://user-images.githubusercontent.com/25568562/67399407-7fded200-f5ac-11e9-9b2e-8adf5e585797.png)
![Screenshot 2019-10-23 at 15 52 00](https://user-images.githubusercontent.com/25568562/67399863-24611400-f5ad-11e9-9e49-7dcf7dceaf26.png)
