### PR TITLE
Add ThenGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Please submit a pull request to improve this file. Thank you to all contributors
 * [BExtension](https://github.com/DominikBucher12/BEExtension) - Xcode Source extension for delivering enums and variables from enum cases, see [this article](https://www.linkedin.com/pulse/xcode-extension-defining-enum-variables-swift-moreerror-bucher?trk=v-feed&lipi=urn%3Ali%3Apage%3Ad_flagship3_feed%3BGQbYZpETZvH9TQq77%2BltRg%3D%3D)
 * [DocumenterXcode](https://github.com/serhii-londar/DocumenterXcode) - Xcode source editor extension which helps you write documentation comment easier, for both Objective-C and Swift.
 * [ViewGenerator](https://github.com/funzin/ViewGenerator) - ViewGenerator generates view code from variable name automatically in iOS development.
+* [ThenGenerator](https://github.com/87kangsw/ThenGenerator) - Xcode Source Editor Extension for 'Then'
 
 ### Helper on editing
 


### PR DESCRIPTION
## ThenGenerator
Link: [ThenGenerator](https://github.com/87kangsw/ThenGenerator)

## Description
ThenGenerator is Xcode Source Editor Extension for '[Then](https://github.com/devxoul/Then)'.
I'm using `Then` very usefully. It was developed to help you use Then.

## Requirement
- macOS 11.0 Big Sur(because using SwiftUI.. 😭)
